### PR TITLE
fix: Correct the location of lean4-mode

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -45,8 +45,8 @@
 (defconst lean4-packages
   '((lean4-mode :location (recipe
                            :fetcher github
-                           :repo "leanprover/lean4"
-                           :files ("lean4-mode/*.el")))
+                           :repo "leanprover/lean4-mode"
+                           :files ("*.el")))
     smartparens
     )
   )


### PR DESCRIPTION
It seems that the location of the lean4-mode files have changed. (They have been moved to their own repo.) This updates packages.el to the new location.

closes: #1